### PR TITLE
Automatically remove polymer imports in bower components

### DIFF
--- a/boiler-plate-app/.bowerrc
+++ b/boiler-plate-app/.bowerrc
@@ -1,0 +1,5 @@
+{
+    "scripts": {
+        "postinstall": "npm run post-install"
+    }
+}

--- a/boiler-plate-app/.bowerrc
+++ b/boiler-plate-app/.bowerrc
@@ -1,5 +1,5 @@
 {
     "scripts": {
-        "postinstall": "npm run post-install"
+        // "postinstall": "npm run post-install"
     }
 }

--- a/boiler-plate-app/.gitignore
+++ b/boiler-plate-app/.gitignore
@@ -1,1 +1,2 @@
 bower_components
+node_modules

--- a/boiler-plate-app/bower.json
+++ b/boiler-plate-app/bower.json
@@ -17,6 +17,7 @@
   },
   "resolutions": {
     "lrndesign-avatar": "^0.0.3",
-    "paper-card": "^1.1.6"
+    "paper-card": "^1.1.6",
+    "webcomponentsjs": "^0.7.0"
   }
 }

--- a/boiler-plate-app/package.json
+++ b/boiler-plate-app/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "boiler-plate-app",
+  "version": "1.0.0",
+  "description": "A LRN element",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "post-install": "node post-install.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "replace": "^0.3.0"
+  }
+}

--- a/boiler-plate-app/post-install.js
+++ b/boiler-plate-app/post-install.js
@@ -1,0 +1,24 @@
+var glob = require("glob");
+var fs = require("fs");
+var replace = require("replace");
+
+// Find file
+glob("bower_components/**/*.html",function (err,files) {
+	if (err) throw err;
+	files.forEach(function (item,index,array){
+		console.log(item + " found");
+     	// Read file
+     	console.log(fs.readFileSync(item,'utf8'));
+     	// Replace string
+     	replace({
+     		regex: "^<import.*polymer.html\W>",
+     		replacement: "",
+     		paths: [item],
+     		recursive: true,
+     		silent: true,
+     	});
+     	console.log("Replacement complete");
+          // Read file
+     	console.log(fs.readFileSync(item,'utf8'));
+      });
+});


### PR DESCRIPTION
Bower has the ability to run post-install scripts.  I made a node script that will find polymer imports and remove them.  I've disabled it by default.

If you want to enable the script:

- `npm install`
- uncomment the `postinstall` property in the .bowerrc file.
- run `bower install`